### PR TITLE
feat(elements): ignore punctuation in `defaultItemFilter`

### DIFF
--- a/.changeset/item-filter-ignore-punctuation.md
+++ b/.changeset/item-filter-ignore-punctuation.md
@@ -1,5 +1,5 @@
 ---
-"@aria-ui/elements": minor
+"@aria-ui/elements": patch
 ---
 
 `defaultItemFilter` now ignores punctuation as well as whitespace, so a query like `#ban` matches an item valued `banana`.

--- a/.changeset/item-filter-ignore-punctuation.md
+++ b/.changeset/item-filter-ignore-punctuation.md
@@ -1,0 +1,5 @@
+---
+"@aria-ui/elements": minor
+---
+
+`defaultItemFilter` now ignores punctuation as well as whitespace, so a query like `#ban` matches an item valued `banana`.

--- a/packages/elements/src/listbox/default-item-filter.test.ts
+++ b/packages/elements/src/listbox/default-item-filter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultItemFilter } from './listbox-root.ts'
+
+function matches(value: string, query: string): boolean {
+  return defaultItemFilter({ value, query })
+}
+
+describe('defaultItemFilter', () => {
+  it('shows every item when the query is empty', () => {
+    expect(matches('Apple', '')).toBe(true)
+  })
+
+  it('shows every item when the query is only whitespace or punctuation', () => {
+    expect(matches('Apple', '   ')).toBe(true)
+    expect(matches('Apple', '#')).toBe(true)
+    expect(matches('Apple', '@/.')).toBe(true)
+  })
+
+  it('matches case-insensitively', () => {
+    expect(matches('Banana', 'ban')).toBe(true)
+    expect(matches('banana', 'BAN')).toBe(true)
+  })
+
+  it('matches a substring anywhere in the value', () => {
+    expect(matches('banana', 'nan')).toBe(true)
+    expect(matches('pineapple', 'apple')).toBe(true)
+  })
+
+  it('does not match when the query is absent from the value', () => {
+    expect(matches('apple', 'xyz')).toBe(false)
+    expect(matches('', 'apple')).toBe(false)
+  })
+
+  it('ignores punctuation in the query', () => {
+    expect(matches('banana', '#ban')).toBe(true)
+    expect(matches('banana', 'b.a.n')).toBe(true)
+  })
+
+  it('ignores punctuation in the value', () => {
+    expect(matches('#banana', 'ban')).toBe(true)
+    expect(matches('c-h-e-r-r-y', 'cherry')).toBe(true)
+  })
+
+  it('ignores whitespace on both sides', () => {
+    expect(matches('Banana Split', 'bananasplit')).toBe(true)
+    expect(matches('bananasplit', 'banana split')).toBe(true)
+  })
+
+  it('drops punctuation entirely, so it never blocks a match', () => {
+    // `c++` normalizes to `c`, which matches the value `c`.
+    expect(matches('c', 'c++')).toBe(true)
+  })
+
+  it('keeps letters and numbers from every script', () => {
+    expect(matches('日本語', '日本')).toBe(true)
+    expect(matches('【日本語】', '日本')).toBe(true)
+    expect(matches('Café', 'café')).toBe(true)
+    expect(matches('item42', '42')).toBe(true)
+  })
+})

--- a/packages/elements/src/listbox/default-item-filter.test.ts
+++ b/packages/elements/src/listbox/default-item-filter.test.ts
@@ -2,60 +2,56 @@ import { describe, expect, it } from 'vitest'
 
 import { defaultItemFilter } from './listbox-root.ts'
 
-function matches(value: string, query: string): boolean {
-  return defaultItemFilter({ value, query })
-}
-
 describe('defaultItemFilter', () => {
   it('shows every item when the query is empty', () => {
-    expect(matches('Apple', '')).toBe(true)
+    expect(defaultItemFilter({ value: 'Apple', query: '' })).toBe(true)
   })
 
   it('shows every item when the query is only whitespace or punctuation', () => {
-    expect(matches('Apple', '   ')).toBe(true)
-    expect(matches('Apple', '#')).toBe(true)
-    expect(matches('Apple', '@/.')).toBe(true)
+    expect(defaultItemFilter({ value: 'Apple', query: '   ' })).toBe(true)
+    expect(defaultItemFilter({ value: 'Apple', query: '#' })).toBe(true)
+    expect(defaultItemFilter({ value: 'Apple', query: '@/.' })).toBe(true)
   })
 
   it('matches case-insensitively', () => {
-    expect(matches('Banana', 'ban')).toBe(true)
-    expect(matches('banana', 'BAN')).toBe(true)
+    expect(defaultItemFilter({ value: 'Banana', query: 'ban' })).toBe(true)
+    expect(defaultItemFilter({ value: 'banana', query: 'BAN' })).toBe(true)
   })
 
   it('matches a substring anywhere in the value', () => {
-    expect(matches('banana', 'nan')).toBe(true)
-    expect(matches('pineapple', 'apple')).toBe(true)
+    expect(defaultItemFilter({ value: 'banana', query: 'nan' })).toBe(true)
+    expect(defaultItemFilter({ value: 'pineapple', query: 'apple' })).toBe(true)
   })
 
   it('does not match when the query is absent from the value', () => {
-    expect(matches('apple', 'xyz')).toBe(false)
-    expect(matches('', 'apple')).toBe(false)
+    expect(defaultItemFilter({ value: 'apple', query: 'xyz' })).toBe(false)
+    expect(defaultItemFilter({ value: '', query: 'apple' })).toBe(false)
   })
 
   it('ignores punctuation in the query', () => {
-    expect(matches('banana', '#ban')).toBe(true)
-    expect(matches('banana', 'b.a.n')).toBe(true)
+    expect(defaultItemFilter({ value: 'banana', query: '#ban' })).toBe(true)
+    expect(defaultItemFilter({ value: 'banana', query: 'b.a.n' })).toBe(true)
   })
 
   it('ignores punctuation in the value', () => {
-    expect(matches('#banana', 'ban')).toBe(true)
-    expect(matches('c-h-e-r-r-y', 'cherry')).toBe(true)
+    expect(defaultItemFilter({ value: '#banana', query: 'ban' })).toBe(true)
+    expect(defaultItemFilter({ value: 'c-h-e-r-r-y', query: 'cherry' })).toBe(true)
   })
 
   it('ignores whitespace on both sides', () => {
-    expect(matches('Banana Split', 'bananasplit')).toBe(true)
-    expect(matches('bananasplit', 'banana split')).toBe(true)
+    expect(defaultItemFilter({ value: 'Banana Split', query: 'bananasplit' })).toBe(true)
+    expect(defaultItemFilter({ value: 'bananasplit', query: 'banana split' })).toBe(true)
   })
 
   it('drops punctuation entirely, so it never blocks a match', () => {
     // `c++` normalizes to `c`, which matches the value `c`.
-    expect(matches('c', 'c++')).toBe(true)
+    expect(defaultItemFilter({ value: 'c', query: 'c++' })).toBe(true)
   })
 
   it('keeps letters and numbers from every script', () => {
-    expect(matches('日本語', '日本')).toBe(true)
-    expect(matches('【日本語】', '日本')).toBe(true)
-    expect(matches('Café', 'café')).toBe(true)
-    expect(matches('item42', '42')).toBe(true)
+    expect(defaultItemFilter({ value: '日本語', query: '日本' })).toBe(true)
+    expect(defaultItemFilter({ value: '【日本語】', query: '日本' })).toBe(true)
+    expect(defaultItemFilter({ value: 'Café', query: 'café' })).toBe(true)
+    expect(defaultItemFilter({ value: 'item42', query: '42' })).toBe(true)
   })
 })

--- a/packages/elements/src/listbox/listbox-root.ts
+++ b/packages/elements/src/listbox/listbox-root.ts
@@ -21,17 +21,22 @@ import { createListboxStore, ListboxStoreContext, type ItemFilter } from './list
 export type { ItemFilter }
 
 /**
- * A simple case-insensitive substring match filter.
+ * A case-insensitive substring filter that ignores whitespace and punctuation,
+ * so a query like `#ban` still matches an item valued `banana`.
  */
 export const defaultItemFilter: ItemFilter = ({ value, query }) => {
-  if (!query) {
+  const normalizedQuery = normalizeFilterText(query)
+  if (!normalizedQuery) {
     return true
   }
 
-  return value
-    .toLowerCase()
-    .replaceAll(/\s/g, '')
-    .includes(query.toLowerCase().replaceAll(/\s/g, ''))
+  return normalizeFilterText(value).includes(normalizedQuery)
+}
+
+// Lowercase and drop everything that is not a letter or number, keeping letters
+// from every script (e.g. CJK and accented characters).
+function normalizeFilterText(text: string): string {
+  return text.toLowerCase().replaceAll(/[^\p{L}\p{N}]/gu, '')
 }
 
 export interface ListboxRootProps {

--- a/packages/elements/src/listbox/listbox.test.ts
+++ b/packages/elements/src/listbox/listbox.test.ts
@@ -225,6 +225,18 @@ describe('Listbox', () => {
       await expect.element(page.getByTestId('banana')).toBeVisible()
     })
 
+    test('query ignores punctuation', async () => {
+      renderListbox(html`
+        <aria-ui-listbox-root .query=${'#ban'}>
+          <aria-ui-listbox-item value="apple" data-testid="apple">Apple</aria-ui-listbox-item>
+          <aria-ui-listbox-item value="banana" data-testid="banana">Banana</aria-ui-listbox-item>
+        </aria-ui-listbox-root>
+      `)
+
+      await expect.element(page.getByTestId('apple')).not.toBeVisible()
+      await expect.element(page.getByTestId('banana')).toBeVisible()
+    })
+
     test('empty component shows when all items are filtered out', async () => {
       renderListbox(html`
         <aria-ui-listbox-root .query=${'xyz'}>


### PR DESCRIPTION
## Problem

`defaultItemFilter` already ignores case and whitespace when matching, but it keeps punctuation significant. That forces callers to strip trigger characters themselves before filtering. For example, a tag autocomplete whose query is `#ban` will not match an item valued `banana`, even though the user clearly means it. Callers work around this by adding a capture group to their regex purely so the trigger is excluded from the query.

## Change

`defaultItemFilter` now normalizes both the query and the item value by lowercasing and dropping everything that is not a letter or number (using `\p{L}`/`\p{N}`, so letters from every script such as CJK and accented characters are preserved). Whitespace stripping is subsumed by this, so existing behavior is unchanged for punctuation-free queries.

```ts
// before: '#ban' did not match 'banana'
// after:  '#ban' matches 'banana'
```

## Why

Normalization for matching belongs in the filter, not in each caller's query construction. With this, a consumer can pass the raw typed query (trigger and all) and still get sensible matches, instead of pre-stripping punctuation or shaping the regex around the filter.

## Compatibility

Behavior change for the default filter: queries that relied on punctuation being significant will now match more loosely. Pass a custom `filter` to opt out. Existing tests pass unchanged; a new test covers the punctuation case.

## Verification

- `pnpm test` (listbox filtering) passes, including a new "query ignores punctuation" case.
- `pnpm lint` (tsc, eslint, knip, oxfmt) passes.
