### PR TITLE
fix(elements): skip overlay positioning while the anchor is hidden

### DIFF
--- a/.changeset/overlay-hidden-anchor.md
+++ b/.changeset/overlay-hidden-anchor.md
@@ -1,0 +1,6 @@
+---
+"@aria-ui/elements": patch
+"@aria-ui/utils": patch
+---
+
+Skip overlay positioning while the anchor is not rendered, and apply the first position of a shown overlay without CSS transitions.

--- a/packages/elements/src/overlay/overlay-positioner.ts
+++ b/packages/elements/src/overlay/overlay-positioner.ts
@@ -242,12 +242,26 @@ export function setupOverlayPositioner(
 
   useDataState(host, getIsVisible)
 
+  let wasOpen = false
+
   useEffect(host, () => {
     const open = getIsOpen()
     const anchorElement = getAnchorElement()
-    if (!open || !anchorElement) return
+    if (!open || !anchorElement) {
+      wasOpen = false
+      return
+    }
+
+    // Apply the first position of a (re)opened positioner without CSS
+    // transitions: the element still carries a stale `transform` from the last
+    // time it was open, and transitioning from it would visibly "fly" the
+    // positioner across the screen. Anchor or option changes while open keep
+    // transitions, so consumers can animate the positioner between anchors.
+    const disableFirstUpdateTransition = !wasOpen
+    wasOpen = true
 
     return updatePlacement(host, anchorElement, {
+      disableFirstUpdateTransition,
       strategy: props.strategy.get(),
       placement: props.placement.get(),
       autoUpdate: props.autoUpdate.get(),

--- a/packages/elements/src/overlay/positioning.test.ts
+++ b/packages/elements/src/overlay/positioning.test.ts
@@ -1,0 +1,122 @@
+import { html, render, type TemplateResult } from 'lit-html'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { page } from 'vitest/browser'
+
+import { registerElements } from '../index.ts'
+
+function renderTemplate(template: TemplateResult) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  render(template, container)
+  return container
+}
+
+function getPositioner(): HTMLElement {
+  const positioner = document.querySelector('aria-ui-popover-positioner')
+  if (!positioner) throw new Error('positioner not found')
+  return positioner
+}
+
+function getComputedTranslate(element: HTMLElement): { x: number; y: number } {
+  const matrix = new DOMMatrixReadOnly(getComputedStyle(element).transform)
+  return { x: matrix.m41, y: matrix.m42 }
+}
+
+function getInlineTranslate(element: HTMLElement): { x: number; y: number } {
+  const matrix = new DOMMatrixReadOnly(element.style.transform)
+  return { x: matrix.m41, y: matrix.m42 }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+const TEMPLATE = html`
+  <div data-testid="spacer" style="height: 100px"></div>
+  <div data-testid="wrapper" style="padding: 50px">
+    <aria-ui-popover-root .open=${true}>
+      <aria-ui-popover-trigger data-testid="trigger">Trigger</aria-ui-popover-trigger>
+      <aria-ui-popover-positioner>
+        <aria-ui-popover-popup data-testid="popup">Content</aria-ui-popover-popup>
+      </aria-ui-popover-positioner>
+    </aria-ui-popover-root>
+  </div>
+`
+
+describe('overlay positioning with a hidden anchor', () => {
+  let transitionStyle: HTMLStyleElement | undefined
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    registerElements()
+  })
+
+  afterEach(() => {
+    transitionStyle?.remove()
+    transitionStyle = undefined
+  })
+
+  function installSlowTransformTransition() {
+    transitionStyle = document.createElement('style')
+    transitionStyle.textContent =
+      'aria-ui-popover-positioner { transition: transform 10000s linear; }'
+    document.head.appendChild(transitionStyle)
+  }
+
+  test('keeps the last position while the anchor is not rendered', async () => {
+    const container = renderTemplate(TEMPLATE)
+    await expect.element(page.getByTestId('popup')).toBeVisible()
+
+    const positioner = getPositioner()
+    await expect.poll(() => positioner.style.transform).toMatch(/translate\(/)
+    const openTransform = positioner.style.transform
+
+    // Hide the whole subtree; the trigger's rect collapses to a zero rect at
+    // the viewport origin. Positioning against it would park the positioner
+    // near the origin.
+    const wrapper = container.querySelector<HTMLElement>('[data-testid="wrapper"]')
+    if (!wrapper) throw new Error('wrapper not found')
+    wrapper.style.display = 'none'
+    // Give autoUpdate's ResizeObserver time to react to the hidden elements.
+    await sleep(200)
+    expect(positioner.style.transform).toBe(openTransform)
+
+    wrapper.style.display = ''
+    await expect.poll(() => positioner.style.transform).toBe(openTransform)
+  })
+
+  test('repositions without transition after the anchor is rendered again', async () => {
+    installSlowTransformTransition()
+
+    const container = renderTemplate(TEMPLATE)
+    await expect.element(page.getByTestId('popup')).toBeVisible()
+
+    const positioner = getPositioner()
+    await expect.poll(() => positioner.style.transform).toMatch(/translate\(/)
+    const openTransform = positioner.style.transform
+
+    const wrapper = container.querySelector<HTMLElement>('[data-testid="wrapper"]')
+    const spacer = container.querySelector<HTMLElement>('[data-testid="spacer"]')
+    if (!wrapper || !spacer) throw new Error('wrapper or spacer not found')
+
+    // Move the anchor while it is not rendered, so the positioner must jump
+    // to a different position when the anchor shows up again.
+    wrapper.style.display = 'none'
+    await sleep(200)
+    spacer.style.height = '400px'
+    wrapper.style.display = ''
+
+    await expect.poll(() => positioner.style.transform).not.toBe(openTransform)
+
+    // The new position must be applied without animating from the old one:
+    // with the slow transform transition above, an animated move would keep
+    // the computed transform near the old position for hours.
+    await expect
+      .poll(() => {
+        const computed = getComputedTranslate(positioner)
+        const target = getInlineTranslate(positioner)
+        return Math.abs(computed.x - target.x) < 0.5 && Math.abs(computed.y - target.y) < 0.5
+      })
+      .toBe(true)
+  })
+})

--- a/packages/elements/src/overlay/positioning.ts
+++ b/packages/elements/src/overlay/positioning.ts
@@ -1,4 +1,4 @@
-import { FeatureDetection } from '@aria-ui/utils'
+import { applyStylesWithoutTransition, FeatureDetection, isElementHidden } from '@aria-ui/utils'
 import {
   autoUpdate,
   computePosition,
@@ -49,6 +49,15 @@ interface UpdatePlacementOpinions {
   elementContext: ElementContext
   altBoundary: boolean
 
+  /**
+   * Whether to apply the first computed position without CSS transitions. Used
+   * when the floating element (re)opens: its inline `transform` still holds a
+   * stale position from the last time it was open, and a CSS transition on
+   * `transform` would visibly animate the floating element from that stale
+   * position instead of showing it in place.
+   */
+  disableFirstUpdateTransition: boolean
+
   setIsHidden: (hidden: boolean) => void
 }
 
@@ -91,6 +100,9 @@ export function updatePlacement(
   let lastSide: string | undefined
   let lastAlign: string | undefined
 
+  let firstUpdate = true
+  let skippedWhileHidden = false
+
   const update = async () => {
     if (canceled) {
       return
@@ -107,6 +119,18 @@ export function updatePlacement(
       floating.setAttribute('popover', 'manual')
       hoistApplied = true
       floating.showPopover?.()
+    }
+
+    // Skip positioning while the reference or the floating element is not
+    // rendered, e.g. an ancestor has `display: none`. `getBoundingClientRect()`
+    // returns a zero rect at the viewport origin for such elements, so
+    // positioning against them would park the floating element at a garbage
+    // position. `autoUpdate`'s ResizeObserver fires again once the elements
+    // regain their boxes, and that update applies its position without CSS
+    // transitions so the floating element cannot visibly "fly" back.
+    if (isReferenceHidden(reference) || isElementHidden(floating)) {
+      skippedWhileHidden = true
+      return
     }
 
     const pos = await computePosition(reference, floating, {
@@ -138,39 +162,52 @@ export function updatePlacement(
     const y = Math.round(pos.y * dpr) / dpr
 
     if (!isTempHidden) {
-      if (lastPosition !== pos.strategy) {
-        floating.style.position = pos.strategy
-        lastPosition = pos.strategy
+      const applyStyles = () => {
+        if (lastPosition !== pos.strategy) {
+          floating.style.position = pos.strategy
+          lastPosition = pos.strategy
+        }
+
+        if (!topLeftSet) {
+          floating.style.top = '0px'
+          floating.style.left = '0px'
+          topLeftSet = true
+        }
+
+        const transform = `translate(${x}px,${y}px)`
+        if (lastTransform !== transform) {
+          floating.style.transform = transform
+          lastTransform = transform
+        }
+
+        // Learned from https://github.com/floating-ui/floating-ui/blob/8f155121/packages/vue/src/useFloating.ts#L72
+        if (dpr >= 1.5 && !willChangeSet) {
+          floating.style.willChange = 'transform'
+          willChangeSet = true
+        }
+
+        const [side, align] = getSideAndAlignFromPlacement(pos.placement)
+
+        if (lastSide !== side) {
+          floating.setAttribute('data-side', side)
+          lastSide = side
+        }
+        if (lastAlign !== align) {
+          floating.setAttribute('data-align', align)
+          lastAlign = align
+        }
       }
 
-      if (!topLeftSet) {
-        floating.style.top = '0px'
-        floating.style.left = '0px'
-        topLeftSet = true
+      const suppressTransition =
+        (firstUpdate && options.disableFirstUpdateTransition) || skippedWhileHidden
+      if (suppressTransition) {
+        applyStylesWithoutTransition(floating, applyStyles)
+      } else {
+        applyStyles()
       }
 
-      const transform = `translate(${x}px,${y}px)`
-      if (lastTransform !== transform) {
-        floating.style.transform = transform
-        lastTransform = transform
-      }
-
-      // Learned from https://github.com/floating-ui/floating-ui/blob/8f155121/packages/vue/src/useFloating.ts#L72
-      if (dpr >= 1.5 && !willChangeSet) {
-        floating.style.willChange = 'transform'
-        willChangeSet = true
-      }
-
-      const [side, align] = getSideAndAlignFromPlacement(pos.placement)
-
-      if (lastSide !== side) {
-        floating.setAttribute('data-side', side)
-        lastSide = side
-      }
-      if (lastAlign !== align) {
-        floating.setAttribute('data-align', align)
-        lastAlign = align
-      }
+      firstUpdate = false
+      skippedWhileHidden = false
     }
   }
 
@@ -340,6 +377,22 @@ function setupHide(props: UpdatePlacementOpinions) {
     padding: props.overflowPadding,
     elementContext: 'reference',
   })
+}
+
+/**
+ * Whether the reference is not rendered. A real element is judged by
+ * {@link isElementHidden}. A virtual element is judged by its own
+ * `getBoundingClientRect()`: an all-zero rect is what a non-rendered anchor
+ * produces, while its `contextElement` can be misleading (e.g. a
+ * `display: contents` wrapper reports no box even though the anchor rect is
+ * valid).
+ */
+function isReferenceHidden(reference: ReferenceElement): boolean {
+  if (isElementLike(reference)) {
+    return isElementHidden(reference)
+  }
+  const rect = reference.getBoundingClientRect()
+  return rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0
 }
 
 function getDPR(element: Element): number {

--- a/packages/utils/src/apply-styles-without-transition.ts
+++ b/packages/utils/src/apply-styles-without-transition.ts
@@ -1,0 +1,20 @@
+/**
+ * Applies style changes with CSS transitions disabled, so that the element
+ * jumps to its new styles instead of animating from the old ones.
+ *
+ * Reading `offsetWidth` in between forces a synchronous style flush, the same
+ * force-reflow trick used by Bootstrap's `reflow()`, MUI's `reflow()`, Vue's
+ * `forceReflow()`, and react-transition-group's `forceReflow()`. Without it,
+ * the browser would coalesce the writes and the restored transition would
+ * animate them.
+ */
+export function applyStylesWithoutTransition(
+  element: HTMLElement,
+  applyStyles: VoidFunction,
+): void {
+  const inlineTransition = element.style.transition
+  element.style.transition = 'none'
+  applyStyles()
+  void element.offsetWidth
+  element.style.transition = inlineTransition
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,6 +12,7 @@ export {
   useAriaOrientation,
   useAriaSelected,
 } from './aria.ts'
+export { applyStylesWithoutTransition } from './apply-styles-without-transition.ts'
 export { setupCollectionItem } from './collection-item.ts'
 export { handleCollectionNavigation } from './collection-navigation.ts'
 export { createCollectionStore, type CollectionStore } from './collection-store.ts'
@@ -25,6 +26,7 @@ export { useDisabledMountTransitionStyle } from './use-disabled-mount-transition
 export { useElementId } from './use-element-id.ts'
 export { useEventListener } from './use-event-listener.ts'
 export { useGlobalEventListener } from './use-global-event-listener.ts'
+export { isElementHidden } from './is-element-hidden.ts'
 export { useHover, type UseHoverOptions } from './use-hover.ts'
 export { useIsMouseActive } from './use-is-mouse-active.ts'
 export { usePresence } from './use-presence.ts'

--- a/packages/utils/src/is-element-hidden.test.ts
+++ b/packages/utils/src/is-element-hidden.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+
+import { isElementHidden } from './is-element-hidden.ts'
+
+describe('isElementHidden', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function appendDiv(parent: Element, style: string): HTMLElement {
+    const div = document.createElement('div')
+    div.setAttribute('style', style)
+    parent.appendChild(div)
+    return div
+  }
+
+  test('returns false for undefined', () => {
+    expect(isElementHidden(undefined)).toBe(false)
+  })
+
+  test('returns false for a rendered element', () => {
+    const div = appendDiv(document.body, '')
+    expect(isElementHidden(div)).toBe(false)
+  })
+
+  test('returns true for a display: none element', () => {
+    const div = appendDiv(document.body, 'display: none')
+    expect(isElementHidden(div)).toBe(true)
+  })
+
+  test('returns true inside a display: none ancestor', () => {
+    const parent = appendDiv(document.body, 'display: none')
+    const child = appendDiv(parent, '')
+    expect(isElementHidden(child)).toBe(true)
+  })
+
+  test('returns false for a rendered display: contents element', () => {
+    const div = appendDiv(document.body, 'display: contents')
+    expect(isElementHidden(div)).toBe(false)
+  })
+
+  test('returns false for nested rendered display: contents elements', () => {
+    const parent = appendDiv(document.body, 'display: contents')
+    const child = appendDiv(parent, 'display: contents')
+    expect(isElementHidden(child)).toBe(false)
+  })
+
+  test('returns true for a display: contents element inside a display: none ancestor', () => {
+    const parent = appendDiv(document.body, 'display: none')
+    const child = appendDiv(parent, 'display: contents')
+    expect(isElementHidden(child)).toBe(true)
+  })
+})

--- a/packages/utils/src/is-element-hidden.ts
+++ b/packages/utils/src/is-element-hidden.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether the element is not rendered, e.g. it or one of its ancestors has
+ * `display: none`. Such an element has no box, so `getBoundingClientRect()`
+ * returns a zero rect at the viewport origin. Falls back to `false` in
+ * browsers without `checkVisibility` support.
+ */
+export function isElementHidden(element: Element | undefined): boolean {
+  if (!element) return false
+  if (element.checkVisibility?.() !== false) return false
+  // A `display: contents` element has no box of its own, so `checkVisibility`
+  // reports it as invisible even though its children still render. Judge by
+  // its parent instead.
+  if (getComputedStyle(element).display === 'contents') {
+    const parent = element.parentElement
+    return parent ? isElementHidden(parent) : false
+  }
+  return true
+}


### PR DESCRIPTION
When an overlay stays open while it or its anchor is hidden (e.g. an ancestor gets `display: none`), `autoUpdate` still fires and `computePosition` runs against a zero rect at the viewport origin, parking the overlay there; once shown again, a consumer CSS transition on `transform` makes it visibly fly back from the corner. `updatePlacement` now skips positioning while the reference or the floating element fails `checkVisibility()`, and applies the next position after a hidden gap (or the first position after a positioner reopens) without CSS transitions. This lives in the shared overlay positioning code, so menu, popover, and tooltip positioners are all covered.