### PR TITLE
feat(elements): add `detail` to `SelectEvent`

### DIFF
--- a/.changeset/select-event-detail.md
+++ b/.changeset/select-event-detail.md
@@ -1,0 +1,5 @@
+---
+"@aria-ui/elements": minor
+---
+
+`SelectEvent` now carries the selected item's value on its `detail` property.

--- a/.changeset/select-event-detail.md
+++ b/.changeset/select-event-detail.md
@@ -1,5 +1,5 @@
 ---
-"@aria-ui/elements": minor
+"@aria-ui/elements": patch
 ---
 
 `SelectEvent` now carries the selected item's value on its `detail` property.

--- a/packages/elements/src/events/index.ts
+++ b/packages/elements/src/events/index.ts
@@ -1,5 +1,11 @@
 export class SelectEvent extends Event {
-  constructor() {
+  /**
+   * The value of the selected item.
+   */
+  readonly detail: string
+
+  constructor(value: string) {
     super('select', { bubbles: false })
+    this.detail = value
   }
 }

--- a/packages/elements/src/events/index.ts
+++ b/packages/elements/src/events/index.ts
@@ -4,7 +4,7 @@ export class SelectEvent extends Event {
    */
   readonly detail: string
 
-  constructor(value: string) {
+  constructor(value: string = '') {
     super('select', { bubbles: false })
     this.detail = value
   }

--- a/packages/elements/src/listbox/listbox-item.ts
+++ b/packages/elements/src/listbox/listbox-item.ts
@@ -91,7 +91,7 @@ export function setupListboxItem(host: HostElement, props: State<ListboxItemProp
     const current = store.selectedValues.get()
     const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value]
     store.emitSelectionChange(next)
-    host.dispatchEvent(new SelectEvent())
+    host.dispatchEvent(new SelectEvent(value))
   })
 }
 

--- a/packages/elements/src/listbox/listbox.test.ts
+++ b/packages/elements/src/listbox/listbox.test.ts
@@ -1,5 +1,5 @@
 import { html, render, type TemplateResult } from 'lit-html'
-import { beforeEach, describe, expect, test } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { page, type Locator } from 'vitest/browser'
 
 import { registerElements } from '../index.ts'
@@ -69,9 +69,13 @@ describe('Listbox', () => {
         </aria-ui-listbox-root>
       `)
 
+      const onSelect = vi.fn()
+      page.getByTestId('apple').element().addEventListener('select', onSelect)
+
       await page.getByTestId('apple').click()
       await expect.element(page.getByTestId('apple')).toHaveAttribute('aria-selected', 'true')
       await expect.element(page.getByTestId('banana')).toHaveAttribute('aria-selected', 'false')
+      expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ detail: 'apple' }))
     })
 
     test('value prop sets initial selection', async () => {

--- a/packages/elements/src/menu/menu-item.ts
+++ b/packages/elements/src/menu/menu-item.ts
@@ -75,7 +75,7 @@ export function setupMenuItem(host: HostElement, props: State<MenuItemProps>) {
     const value = props.value.get()
     store.setHighlightedValue(value)
 
-    host.dispatchEvent(new SelectEvent())
+    host.dispatchEvent(new SelectEvent(value))
 
     if (props.closeOnSelect.get()) {
       closeMenuTree(store)

--- a/packages/elements/src/menu/menu.test.ts
+++ b/packages/elements/src/menu/menu.test.ts
@@ -242,6 +242,7 @@ describe('Menu', () => {
       page.getByTestId('copy').element().addEventListener('select', onSelect)
       await page.getByTestId('copy').click()
       await vi.waitFor(() => expect(onSelect).toHaveBeenCalled())
+      expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ detail: 'copy' }))
       await expect.element(getMenu().popup).toHaveAttribute('data-state', 'closed')
     })
 


### PR DESCRIPTION
`SelectEvent` now carries the selected item's value on its `detail` property, matching the other event classes (`ValueChangeEvent`, `OpenChangeEvent`), so `select` listeners can tell which item fired without closing over it.